### PR TITLE
mRevert "Bump next from 15.5.18 to 15.5.21 in the npm_and_yarn group across 1 directory"

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "15.5.21",
+    "next": "15.5.18",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },


### PR DESCRIPTION
Reverts Dev-moe-kyawaung/Premium-Nextjs-Portfolio#3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the Dependabot upgrade and pins `next` back to 15.5.18. This restores the previously tested framework version and avoids unvetted changes from 15.5.21.

- Only `package.json` changes; no app code is touched.
- Run `npm install` or `yarn install` to ensure `next@15.5.18` is resolved in the lockfile.
- Verify local dev (`next dev`) and production build (`next build && next start`) complete as before.

<sup>Written for commit 89dcaf25548fff3ea2163bf2594e8073d0a442b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Dev-moe-kyawaung/Premium-Nextjs-Portfolio/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

